### PR TITLE
Support rubocop v0.54.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+## v0.1.0
+
+* Upgrade rubocop support to `>= v0.54.0`.
+
+## v0.0.1
+
+* Initial Release

--- a/lib/rubocop/lint/swallowed_exception.rb
+++ b/lib/rubocop/lint/swallowed_exception.rb
@@ -8,14 +8,14 @@ module RuboCop
       # determines whether exceptions are being handled correctly
       def on_resbody(node)
         unless node.children[2]
-          add_offense(node, :expression, 'rescue body is empty!', :fatal)
+          add_offense(node, location: :expression, message: 'rescue body is empty!', severity: :fatal)
           return
         end
         body = node.children[2]
         return if raises?(body)
         return if newrelic_captured_exception?(body)
         # rubocop:disable Style/RedundantParentheses
-        add_offense(node, :expression, (<<-MSG).strip, :fatal)
+        add_offense(node, location: :expression, message: (<<-MSG).strip, severity: :fatal)
         you have to raise exception or capture exception by NewRelic in rescue body.
         MSG
         # rubocop:enable Style/RedundantParentheses

--- a/lib/rubocop/rails/errors_add_with_symbol.rb
+++ b/lib/rubocop/rails/errors_add_with_symbol.rb
@@ -10,6 +10,8 @@ module RuboCop
     # languages. That's not possible when already translated strings are
     # passed to this method.
     class ErrorsAddWithSymbol < RuboCop::Cop::Cop
+      include RuboCop::Cop::RangeHelp
+
       MSG = 'Only pass symbols to `errors.add`'.freeze
 
       def_node_matcher :errors_add?, <<-PATTERN
@@ -37,7 +39,7 @@ module RuboCop
         range = range_between(node.arguments[1].loc.expression.begin_pos,
                               node.arguments[1].loc.expression.end_pos)
 
-        add_offense(node, range, format(MSG))
+        add_offense(node, location: range, message: format(MSG))
       end
     end
   end

--- a/rubocop-custom-cops.gemspec
+++ b/rubocop-custom-cops.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.51.0'
+  spec.add_dependency 'rubocop', '>= 0.54.0'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'pry'

--- a/rubocop-custom-cops.gemspec
+++ b/rubocop-custom-cops.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-custom-cops'
-  spec.version       = '0.0.1'
+  spec.version       = '0.1.0'
   spec.authors       = ['Sage One team']
   spec.email         = ['support@sageone.com']
 


### PR DESCRIPTION
* `range_between` was removed from `RuboCop::Cop::Util` which `RuboCop::Cop::Cop` included by default in https://github.com/bbatsov/rubocop/pull/5366 . Fix is to include the new `RuboCop::Cop::RangeHelp` helper
* `add_offense` API changed to use named parameters in v0.51.0 and backwards compatibility was removed in v0.52.0

* Bump gem to v0.1.0